### PR TITLE
Fixing inHeight and inWidth ...

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -3,7 +3,7 @@ README
 
 Downloads
 ---------
-* [VDADecoderChecker Binary (0.20)](https://github.com/cylonbrain/VDADecoderCheck/releases/download/0.20/VDADecoderChecker) - Download precompiled binary (Intel 64-Bit):
+* Sorry - no precompiled binary from this fork.
 
 Summary
 ----------

--- a/VDADecoderChecker.cpp
+++ b/VDADecoderChecker.cpp
@@ -69,8 +69,8 @@ OSStatus CreateDecoder(void)
     VDADecoder decoderOut = NULL;
 
     OSType inSourceFormat='avc1';
-    SInt32 inHeight = 1920;
-    SInt32 inWidth = 1080;
+    SInt32 inHeight = 720;
+    SInt32 inWidth = 1280;
 
     inAVCCData = CFDataCreate(kCFAllocatorDefault, avcC_subler, sizeof(avcC_subler)*sizeof(UInt8));
 


### PR DESCRIPTION
... to solve the 'GVA error: Output resolution bigger than video resolution'
which results in  'VDADecoderCreate failed. err: -12473'
With this fix, I got 'Hardware acceleration is fully supported' again.